### PR TITLE
Fix README.md code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ server = GSIServer(("127.0.0.1", 3000), "S8RL9Z6Y22TYQK45JB4V8PHRJJMD9DS9")
 server.start_server()
 
 server.get_info("map", "name")
-server.get_info("player", "state", "flashed)
+server.get_info("player", "state", "flashed")
 ```


### PR DESCRIPTION
Hi! You have missed quote symbol in `README.md` code example.